### PR TITLE
Windows colors support (cmd & PowerShell) + extra options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 Thumbs.db
+debug

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-.DS_Store
-Thumbs.db
-debug

--- a/ansimage/draw_other.go
+++ b/ansimage/draw_other.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package ansimage
+
+func EnableColorsInTerminal() {
+	// no need to do anything in Linux
+}

--- a/ansimage/draw_win.go
+++ b/ansimage/draw_win.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package ansimage
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var (
+	kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+	procSetConsoleMode = kernel32.NewProc("SetConsoleMode")
+)
+
+func EnableColorsInTerminal() {
+	handle := syscall.Stdout
+	if terminal.IsTerminal(int(handle)) {
+
+		var consoleMode int32
+
+		procGetConsoleMode.Call(uintptr(handle), uintptr(unsafe.Pointer(&consoleMode)))
+		consoleMode |= 0x0004
+		procSetConsoleMode.Call(uintptr(handle), uintptr(consoleMode))
+	}
+}

--- a/pixterm.go
+++ b/pixterm.go
@@ -40,12 +40,14 @@ const (
 )
 
 var (
-	flagCredits bool
-	flagDither  uint
-	flagMatte   string
-	flagScale   uint
-	flagRows    uint
-	flagCols    uint
+	flagCredits  bool
+	flagPrintSrc bool
+	flagTrans    bool
+	flagDither   uint
+	flagMatte    string
+	flagScale    uint
+	flagRows     uint
+	flagCols     uint
 )
 
 func main() {
@@ -113,6 +115,8 @@ func configureFlags() {
 	flag.CommandLine.UintVar(&flagScale, "s", 0, "scale `method`:\n   0 - resize (default)\n   1 - fill\n   2 - fit")
 	flag.CommandLine.UintVar(&flagRows, "tr", 0, "terminal `rows` (optional, >=2; when piping, default: 24)")
 	flag.CommandLine.UintVar(&flagCols, "tc", 0, "terminal `columns` (optional, >=2; when piping, default: 80)")
+	flag.CommandLine.BoolVar(&flagPrintSrc, "code", false, "outputs code to 'Printf' image from your app")
+	flag.CommandLine.BoolVar(&flagTrans, "trans", false, "transparent background")
 
 	flag.CommandLine.Parse(os.Args[1:])
 }
@@ -209,8 +213,11 @@ func runPixterm() {
 		throwError(1, err)
 	}
 
+	pix.PrintSrc = flagPrintSrc
+	pix.Transparent = flagTrans
 	// draw ANSImage to terminal
 	if isTerminal() {
+		ansimage.EnableColorsInTerminal()
 		ansimage.ClearTerminal()
 	}
 	pix.SetMaxProcs(runtime.NumCPU()) // maximum number of parallel goroutines!


### PR DESCRIPTION
1) Adds Windows console colors support for Command Prompt and PowerShell
2) Adds option to output format string instead of image. Output then can be used in Printf function to print image in users application.
3) Adds option to disable setting backgrounds for cahracters
