### PR TITLE
Add compiled PIXterm binaries to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 Thumbs.db
 vendor/
+
+# Compiled binaries
+pixterm
+pixterm.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 Thumbs.db
 vendor/
 
-# Compiled binaries
-pixterm
-pixterm.exe
+# compiled binaries
+/cmd/pixterm/pixterm
+/cmd/pixterm/pixterm.exe


### PR DESCRIPTION
This avoids committing them by mistake.