### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ If you use Arch Linux, `eigengrau` has kindly created an AUR package for **`PIXt
 
 `yaourt -S pixterm-git`
 
+If you use an Apple device you may need to run this command before building the binary:
+`go get -u golang.org/x/sys`
+
 #### About
 
 **`PIXterm`** is a terminal toy application that I made to exercise my skills on Go programming language. If you have not tried this language yet, please give it a try! It's easy, fast and very well organized. You'll not regret 😜

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you use Arch Linux, `eigengrau` has kindly created an AUR package for **`PIXt
 `yaourt -S pixterm-git`
 
 If you use an Apple device you may need to run this command before building the binary:
-`go get -u golang.org/x/sys`
+`go get -u golang.org/x/sys` or `go get -u all`
 
 #### About
 


### PR DESCRIPTION
`Unix/Go` package is required be updated to the latest if you are on go version 1.19
added the command to readme `for apple devices` because it is **not done by default** (with `go get` or `go mod tidy`)
and **only some go project  repos** will trigger this requirement